### PR TITLE
put nat gateways in public subnets

### DIFF
--- a/gateways.tf
+++ b/gateways.tf
@@ -6,11 +6,11 @@ resource "aws_internet_gateway" "internet_gw" {
 resource "aws_nat_gateway" "pvt_subnet_nats" {
   for_each = aws_subnet.subnets_private
 
-  subnet_id = each.value.id
+  subnet_id = element([for subnet in aws_subnet.subnets_public: subnet.id], 
+              index([for subnet in aws_subnet.subnets_private:  subnet.id], each.value.id)) # put nat gateways in public subnet
 
   allocation_id = aws_eip.eip_for_nat[each.key].id
 
-  depends_on = [aws_internet_gateway.internet_gw]
 }
 
 # every NAT needs an EIP


### PR DESCRIPTION
fix the error of putting the nat gateways in the private subnets. they should be in the public subnets.